### PR TITLE
Enable jar builds for Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,3 +8,8 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies += "org.apache.lucene" % "lucene-core" % "8.5.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.5.1" % "provided"
+
+// Package a runnable JAR for Spark with sbt-assembly
+enablePlugins(AssemblyPlugin)
+assembly / mainClass := Some("SparkReader")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")

--- a/src/main/scala/AsyncReader.scala
+++ b/src/main/scala/AsyncReader.scala
@@ -1,0 +1,35 @@
+import org.apache.lucene.index.{DirectoryReader, IndexReader}
+import org.apache.lucene.store.FSDirectory
+import java.nio.file.Paths
+import scala.concurrent.{ExecutionContext, Future, Await}
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
+import java.util.concurrent.Executors
+
+object AsyncReader extends App {
+  val dataPath = if (args.length > 0) args(0) else "path"
+
+  val threadPool = Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors())
+  given ExecutionContext = ExecutionContext.fromExecutorService(threadPool)
+
+  val readFuture = Future {
+    val index = FSDirectory.open(Paths.get(dataPath))
+    val reader: IndexReader = DirectoryReader.open(index)
+    try {
+      (0 until reader.maxDoc()).foreach { i =>
+        val doc = reader.document(i)
+        val source = doc.getBinaryValue("_source").utf8ToString()
+        println(source)
+      }
+    } finally {
+      reader.close()
+      index.close()
+    }
+  }
+
+  readFuture.onComplete {
+    case _ => threadPool.shutdown()
+  }
+
+  Await.result(readFuture, Duration.Inf)
+}

--- a/src/main/scala/SparkReader.scala
+++ b/src/main/scala/SparkReader.scala
@@ -1,0 +1,41 @@
+import org.apache.spark.sql.SparkSession
+import org.apache.lucene.index.{DirectoryReader, IndexReader}
+import org.apache.lucene.store.FSDirectory
+import java.nio.file.Paths
+
+/** Simple Spark job that reads a Lucene index in parallel. */
+object SparkReader {
+  def main(args: Array[String]): Unit = {
+    val dataPath = if (args.nonEmpty) args(0) else "path"
+
+    val spark = SparkSession.builder().appName("LuceneSparkReader").getOrCreate()
+    try {
+      val docs = spark.sparkContext
+        .parallelize(0 until countDocs(dataPath), spark.sparkContext.defaultParallelism)
+        .mapPartitions { it =>
+          val index = FSDirectory.open(Paths.get(dataPath))
+          val reader: IndexReader = DirectoryReader.open(index)
+          val res = it.map { i =>
+            val doc = reader.document(i)
+            doc.getBinaryValue("_source").utf8ToString()
+          }.toList
+          reader.close()
+          index.close()
+          res.iterator
+        }
+
+      docs.collect().foreach(println)
+    } finally {
+      spark.stop()
+    }
+  }
+
+  private def countDocs(path: String): Int = {
+    val index = FSDirectory.open(Paths.get(path))
+    val reader = DirectoryReader.open(index)
+    val count = reader.maxDoc()
+    reader.close()
+    index.close()
+    count
+  }
+}


### PR DESCRIPTION
## Summary
- enable the sbt-assembly plugin for building runnable jars
- set the SparkReader as the main class

## Testing
- `sbt assembly` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b6f69e3bc8327ace7af171d1ef309